### PR TITLE
now works in phpunit6/7, remove superfluous output from --debug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": ">=6.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/DiabloMedia/PHPUnit/Printer/PrettyPrinter.php
+++ b/src/DiabloMedia/PHPUnit/Printer/PrettyPrinter.php
@@ -2,6 +2,9 @@
 
 namespace DiabloMedia\PHPUnit\Printer;
 
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\PhptTestCase;
+
 class PrettyPrinter extends \PHPUnit\TextUI\ResultPrinter implements \PHPUnit\Framework\TestListener
 {
     protected $className;
@@ -38,9 +41,10 @@ class PrettyPrinter extends \PHPUnit\TextUI\ResultPrinter implements \PHPUnit\Fr
 
     public function endTest(\PHPUnit\Framework\Test $test, $time): void
     {
-        parent::endTest($test, $time);
 
-        if ($this->debug) {
+        if (!$this->debug) {
+            parent::endTest($test, $time);
+        } else {
             foreach ($this->timeColors as $threshold => $color) {
                 if ($time >= $threshold) {
                     $timeColor = $color;
@@ -59,6 +63,20 @@ class PrettyPrinter extends \PHPUnit\TextUI\ResultPrinter implements \PHPUnit\Fr
             }
 
             $this->writeWithColor('fg-cyan', $msg, true);
+
+            // Necessary part from \PHPUnit\TextUI\ResultPrinter::endTest
+            if ($test instanceof TestCase) {
+                $this->numAssertions += $test->getNumAssertions();
+            } elseif ($test instanceof PhptTestCase) {
+                $this->numAssertions++;
+            }
+
+            $this->lastTestFailed = false;
+            if ($test instanceof TestCase) {
+                if (!$test->hasExpectationOnOutput()) {
+                    $this->write($test->getActualOutput());
+                }
+            }
         }
     }
 

--- a/src/DiabloMedia/PHPUnit/Printer/PrettyPrinter.php
+++ b/src/DiabloMedia/PHPUnit/Printer/PrettyPrinter.php
@@ -51,7 +51,14 @@ class PrettyPrinter extends \PHPUnit\TextUI\ResultPrinter implements \PHPUnit\Fr
             $this->write(' ');
             $this->writeWithColor($timeColor, '['.number_format($time, 3).'s]', false);
             $this->write(' ');
-            $this->writeWithColor('fg-cyan', implode(',', \PHPUnit\Util\Test::describe($test)), true);
+
+            if (method_exists('\PHPUnit\Util\Test', 'describeAsString')) {
+                $msg = \PHPUnit\Util\Test::describeAsString($test);
+            } else {
+                $msg = \PHPUnit\Util\Test::describe($test); // PHPUnit <= 6
+            }
+
+            $this->writeWithColor('fg-cyan', $msg, true);
         }
     }
 


### PR DESCRIPTION
* Adding a small conditional to allow this to work with both phpunit6 and phpunit7
* It seems that at some point the `\PHPUnit\TextUI\ResultPrinter::endTest` method started printing its own debug output, which was adding extra lines to our output (here, to be exact: https://github.com/sebastianbergmann/phpunit/commit/be8d74fda05e095e3a104c5af1a7b772014e6ebb), so I'm no longer calling the parent and instead copied the assertion logic into our `endTest` method.

I've tested these changes in PHPUnit 6.0, 6.5.7, and 7.0.2.
