### PR TITLE
ignore all cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 composer.lock
 .php_cs
-.php_cs.cache
+.*.cache
 vendor


### PR DESCRIPTION
Latest phpunit is using a new cache file, named `.phpunit.result.cache`
With proposed change, such file is also ignored (as well as any possible future cache file)