### PR TITLE
Adding Dependabot v2, updating build badge in Readme

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+    - package-ecosystem: composer
+      directory: '/'
+      schedule:
+          interval: daily
+    - package-ecosystem: github-actions
+      directory: '/'
+      schedule:
+          interval: daily

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # phpunit-pretty-printer
-[![Build Status](https://api.travis-ci.com/diablomedia/phpunit-pretty-printer.svg?branch=master)](https://travis-ci.com/diablomedia/phpunit-pretty-printer)
+
+[![Build](https://github.com/diablomedia/phpunit-pretty-printer/workflows/Build/badge.svg?event=push)](https://github.com/diablomedia/phpunit-pretty-printer/actions?query=workflow%3ABuild+event%3Apush)
 [![Latest Stable Version](https://poser.pugx.org/diablomedia/phpunit-pretty-printer/v/stable)](https://packagist.org/packages/diablomedia/phpunit-pretty-printer)
 [![Total Downloads](https://poser.pugx.org/diablomedia/phpunit-pretty-printer/downloads)](https://packagist.org/packages/diablomedia/phpunit-pretty-printer)
 [![License](https://poser.pugx.org/diablomedia/phpunit-pretty-printer/license)](https://packagist.org/packages/diablomedia/phpunit-pretty-printer)
@@ -38,12 +39,11 @@ Optionally, you can add it to your project's `phpunit.xml` file instead:
 
 Default output:
 
-![phpunit-pretty-printer](https://cloud.githubusercontent.com/assets/1278449/13678034/d76eda8a-e6a9-11e5-8c6b-04b6ec9976eb.png "Default output")
-
+![phpunit-pretty-printer](https://cloud.githubusercontent.com/assets/1278449/13678034/d76eda8a-e6a9-11e5-8c6b-04b6ec9976eb.png 'Default output')
 
 Debug output showing time to run:
 
-![phpunit-pretty-printer-debug](https://cloud.githubusercontent.com/assets/1278449/13678037/e0a09986-e6a9-11e5-891a-08c7b6389fca.png "Debug output showing time to run")
+![phpunit-pretty-printer-debug](https://cloud.githubusercontent.com/assets/1278449/13678037/e0a09986-e6a9-11e5-891a-08c7b6389fca.png 'Debug output showing time to run')
 
 ## Acknowledgements
 


### PR DESCRIPTION
This adds a Dependabot v2 config, also changes the Build badge in the Readme to point to github-actions results rather than travis-ci.com.