### PR TITLE
Supporting PHPUnit 9.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,8 @@ jobs:
             - name: Static Analysis
               run: composer static-analysis
             - name: Code Style Check
+              env:
+                  PHP_CS_FIXER_IGNORE_ENV: true
               run: composer check-style -- --format=checkstyle | cs2pr
             - name: Test
               run: composer tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
             fail-fast: false
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: ['7.3', '7.4', '8.0']
+                php-versions: ['7.3', '7.4', '8.0', '8.1']
                 composer-args: ['', '--prefer-lowest']
         runs-on: ${{ matrix.operating-system }}
         steps:
@@ -43,16 +43,3 @@ jobs:
               run: composer check-style -- --format=checkstyle | cs2pr
             - name: Test
               run: composer tests
-    merge-me:
-        name: Merge me!
-        needs:
-            - build
-        runs-on: ubuntu-latest
-        steps:
-            - name: Merge me!
-              uses: ridedott/merge-me-action@master
-              with:
-                  # This must be used as GitHub Actions token does not support
-                  # pushing to protected branches.
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  GITHUB_LOGIN: 'dependabot[bot]'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
             fail-fast: false
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: ['7.1', '7.2', '7.3', '7.4']
+                php-versions: ['7.3', '7.4', '8.0']
                 composer-args: ['', '--prefer-lowest']
         runs-on: ${{ matrix.operating-system }}
         steps:

--- a/.github/workflows/merge-me.yml
+++ b/.github/workflows/merge-me.yml
@@ -1,0 +1,32 @@
+name: Merge me!
+
+on:
+  workflow_run:
+    types:
+      - completed
+    workflows:
+      - 'Build'
+
+jobs:
+  merge-me:
+    name: Merge me!
+    runs-on: ubuntu-latest
+    steps:
+      - # It is often a desired behavior to merge only when a workflow execution
+        # succeeds. This can be changed as needed.
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        name: Merge me!
+        uses: ridedott/merge-me-action@v2
+        with:
+          # Depending on branch protection rules, a  manually populated
+          # `GITHUB_TOKEN_WORKAROUND` secret with permissions to push to
+          # a protected branch must be used. This secret can have an arbitrary
+          # name, as an example, this repository uses `DOTTBOTT_TOKEN`.
+          #
+          # When using a custom token, it is recommended to leave the following
+          # comment for other developers to be aware of the reasoning behind it:
+          #
+          # This must be used as GitHub Actions token does not support pushing
+          # to protected branches.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENABLE_GITHUB_API_PREVIEW: true

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -7,8 +7,8 @@ $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
 ;
 
-return PhpCsFixer\Config::create()
-    ->setRiskyAllowed(true)
+$config = new PhpCsFixer\Config();
+return $config->setRiskyAllowed(true)
     ->setRules([
         '@PSR2' => true,
         '@PHP70Migration' => true,
@@ -16,6 +16,10 @@ return PhpCsFixer\Config::create()
         '@PHP71Migration:risky' => true,
         '@PHPUnit60Migration:risky' => true,
         'binary_operator_spaces' => ['align_double_arrow' => true, 'align_equals' => true],
+        'binary_operator_spaces' => array(
+            'default'   => 'align_single_space_minimal',
+            'operators' => array('||' => null, '&&' => null)
+        ),
         'single_quote' => false,
         'array_syntax' => ['syntax' => 'short'],
         'concat_space' => ['spacing' => 'one'],

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,15 @@
             "name": "Ari Pringle",
             "email": "ari@diablomedia.com",
             "homepage": "https://diablomedia.com"
+        },
+        {
+            "name": "Jay Klehr",
+            "email": "jay@diablomedia.com",
+            "homepage": "https://diablomedia.com"
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.3 || ^8.0.0 || ^8.1.0",
         "phpunit/phpunit": "^9.0"
     },
     "autoload": {
@@ -29,9 +34,9 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "2.18.2",
+        "friendsofphp/php-cs-fixer": "3.3.2",
         "nazar-pc/phpt-tests-runner": "^1.4.0",
-        "phpstan/phpstan": "0.12.77"
+        "phpstan/phpstan": "1.2.0"
     },
     "scripts": {
         "check-style": "php-cs-fixer fix --dry-run -vv",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,13 @@
     "name": "diablomedia/phpunit-pretty-printer",
     "type": "library",
     "description": "A PHPUnit result printer that shows per-file test progress and execution times",
-    "keywords": ["phpunit","result", "printer", "unit", "test"],
+    "keywords": [
+        "phpunit",
+        "result",
+        "printer",
+        "unit",
+        "test"
+    ],
     "homepage": "https://github.com/diablomedia/phpunit-pretty-printer",
     "license": "MIT",
     "authors": [
@@ -13,8 +19,8 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "phpunit/phpunit": "^7.1 || ^8.0"
+        "php": "^7.3 || ^8.0",
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {
@@ -23,9 +29,9 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "2.16.7",
+        "friendsofphp/php-cs-fixer": "2.18.2",
         "nazar-pc/phpt-tests-runner": "^1.4.0",
-        "phpstan/phpstan": "0.12.46"
+        "phpstan/phpstan": "0.12.77"
     },
     "scripts": {
         "check-style": "php-cs-fixer fix --dry-run -vv",

--- a/src/DiabloMedia/PHPUnit/Printer/PrettyPrinter.php
+++ b/src/DiabloMedia/PHPUnit/Printer/PrettyPrinter.php
@@ -5,8 +5,10 @@ namespace DiabloMedia\PHPUnit\Printer;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Runner\PhptTestCase;
+use PHPUnit\TextUI\DefaultResultPrinter;
+use PHPUnit\Framework\TestListener;
 
-class PrettyPrinter extends \PHPUnit\TextUI\ResultPrinter implements \PHPUnit\Framework\TestListener
+class PrettyPrinter extends DefaultResultPrinter implements TestListener
 {
     /**
      * @var string

--- a/src/DiabloMedia/PHPUnit/Printer/PrettyPrinter.php
+++ b/src/DiabloMedia/PHPUnit/Printer/PrettyPrinter.php
@@ -147,9 +147,9 @@ class PrettyPrinter extends DefaultResultPrinter implements TestListener
 
         if ($this->colors) {
             $exceptionMessage = preg_replace('/^(Exception.*)$/m', "\033[01;31m$1\033[0m", $exceptionMessage) ?? '';
-            $exceptionMessage = preg_replace('/^(Failed.*)$/m', "\033[01;31m$1\033[0m", $exceptionMessage) ?? '';
-            $exceptionMessage = preg_replace("/^(\-+.*)$/m", "\033[01;32m$1\033[0m", $exceptionMessage) ?? '';
-            $exceptionMessage = preg_replace("/^(\++.*)$/m", "\033[01;31m$1\033[0m", $exceptionMessage) ?? '';
+            $exceptionMessage = preg_replace('/^(Failed.*)$/m', "\033[01;31m$1\033[0m", $exceptionMessage)    ?? '';
+            $exceptionMessage = preg_replace("/^(\-+.*)$/m", "\033[01;32m$1\033[0m", $exceptionMessage)       ?? '';
+            $exceptionMessage = preg_replace("/^(\++.*)$/m", "\033[01;31m$1\033[0m", $exceptionMessage)       ?? '';
         }
 
         return $exceptionMessage;


### PR DESCRIPTION
Fixes #57 .

Due to class visibility changes in PHPUnit 9, this requires extending a different class for the printer, so isn't really backwards compatible with PHPUnit 8.x (we could possibly achieve this with class aliasing, but that seems complicated).

This will be a major version bump.

PHPUnit 9 also only supports PHP 7.3 and up, so changing the mimimum allowed php versions to match.